### PR TITLE
Combine logline filters into anyfilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,20 @@ By default it parses `/etc/nginx/nginx.conf` and all includes, but you can speci
 app@wifbtb-testalex-magweb-cmbl:~$ nginx-static-analysis -f /some/other/nginx.conf directive location
 ...
 ```
+
+## Feeding logs into the analysis
+
+You can feed access/error logs into the analysis by piping it into stdin:
+```
+app@wifbtb-testalex-magweb-cmbl:~$ tail /var/log/nginx/access.log -n1 | nginx-static-analysis d location
++----------------------------------------------------+--------+------------------------------------------+
+|                        File                        | Values |                Directives                |
++----------------------------------------------------+--------+------------------------------------------+
+|            /etc/nginx/testsite.conf:18             |   /    |  http -> include -> server -> location   |
+| /etc/nginx/sites/http.testalex.hypernode.io.conf:8 |   /    |            server -> location            |
+|            /etc/nginx/magento2.conf:17             |   /    | server -> include -> include -> location |
++----------------------------------------------------+--------+------------------------------------------+
+```
+
+The analysis creates filters based on the incoming loglines. Those filters are combined with the arguments given
+to the `nginx-static-analysis` command.

--- a/nginx_analysis/filter.py
+++ b/nginx_analysis/filter.py
@@ -27,7 +27,7 @@ def args_to_filter(
     )
 
 
-def logline_to_filters(logline: dict) -> CombinedFilters:
+def logline_to_filter(logline: dict) -> CombinedFilters:
     filters = AllFilter()
     if "server_name" in logline:
         filters += DirectiveFilter(

--- a/tests/unit/log/test_logline_to_filters.py
+++ b/tests/unit/log/test_logline_to_filters.py
@@ -1,12 +1,12 @@
 from nginx_analysis.dataclasses import AllFilter, DirectiveFilter
-from nginx_analysis.filter import logline_to_filters
+from nginx_analysis.filter import logline_to_filter
 from tests.testcase import TestCase
 
 
 class TestLoglineToFilters(TestCase):
     def test_server_name_is_set_as_filter(self):
         parsed_line = {"server_name": "example.com"}
-        filters = logline_to_filters(parsed_line)
+        filters = logline_to_filter(parsed_line)
         self.assertEqual(
             filters,
             AllFilter(
@@ -16,7 +16,7 @@ class TestLoglineToFilters(TestCase):
 
     def test_location_is_parsed_from_request(self):
         parsed_line = {"request": "GET /foo/bar"}
-        filters = logline_to_filters(parsed_line)
+        filters = logline_to_filter(parsed_line)
         self.assertEqual(
             filters,
             AllFilter(
@@ -26,5 +26,5 @@ class TestLoglineToFilters(TestCase):
 
     def test_unknown_directive_is_ignored(self):
         parsed_line = {"foo": "bar"}
-        filters = logline_to_filters(parsed_line)
+        filters = logline_to_filter(parsed_line)
         self.assertEqual(filters, AllFilter(filters=[]))


### PR DESCRIPTION
Create an AllFilter per logline and combine those into an AnyFilter to show directives matching _any_ of the loglines, not _all_ of the loglines.