### PR TITLE
Only return top-level lines that fully match

### DIFF
--- a/example_nginx/nginx.conf
+++ b/example_nginx/nginx.conf
@@ -20,10 +20,6 @@ http {
     server_names_hash_bucket_size 256;
     # server_name_in_redirect off;
 
-    # default: 1m, so required to allow photo uploads
-    # see ticket #1315276 --WdG
-    client_max_body_size 120m;
-
     default_type application/octet-stream;
 
     gzip on;
@@ -33,51 +29,14 @@ http {
     gzip_proxied any;
     gzip_types text/xml text/plain text/css text/js application/xml application/javascript application/json image/svg image/svg+xml image/eps;
 
-    # Rate limit all non-google/bing bots
-    # https://gist.github.com/supairish/2951524
-    # (Alternatively, use key $binary_remote_addr to rate limit per ip.)
-    # This config shares the same rate for all bots.
-    # These regexes are case-insensitive. --WdG
-    map $http_user_agent $limit_bots {
-        default '';
-        ~*(google|bing|heartbeat|uptimerobot|shoppimon|facebookexternal|monitis.com|Zend_Http_Client|magereport.com|SendCloud/|Adyen|ForusP|contentkingapp|node-fetch) '';
-        ~*(http|crawler|spider|bot|search|Wget/|Python-urllib|PHPCrawl|bGenius|MauiBot|aspiegel) 'bot';
-    }
-
-    # Don't ratelimit when bot request went through Varnish
-    # Turpentine sets the X-Varnish-Esi-Method header. If you don't use
-    # Turpentine you need to define this in your VCL yourself.
-    # See http://stackoverflow.com/a/29767034/4158804 for information about how mapping the header works
-    # See http://stackoverflow.com/a/30083902/4158804 for information about mapping variables twice
-    map $http_x_varnish_esi_method $limit {
-        default $limit_bots;
-        "~.+" '';
-    }
-
-    # An empty '$limit_bots' would disable rate limiting for this requests
-    limit_req_zone $limit zone=bots:1m rate=1r/s;
     limit_req_log_level error;
 
     # Nginx returns 503 when rate limited, but some Magento plugins also emit 503.
     # Besides, 429 is more semantic.
     limit_req_status 429;
 
-    # Limit amount of active dynamic requests per source IP address
-    map $binary_remote_addr $conn_limit_map {
-        default $binary_remote_addr;
-    }
-
-    # Exclude HeartBeat servers IPs from connection rate limits.
-    map $remote_addr $limit_conn_per_ip {
-        144.202.77.136 '';  # heartbeat1
-        172.104.161.173 '';  # heartbeat2
-        87.233.224.226 '';  # heartbeat3
-        default $conn_limit_map;
-    }
-
     # This is the conn limit per IP, so that a single IP
     # cannot saturate all PHP slots. See also handler.conf
-    limit_conn_zone $limit_conn_per_ip zone=zoneperip:10m;
     limit_conn_status 429;
 
     index index.html index.php;

--- a/nginx_analysis/analysis.py
+++ b/nginx_analysis/analysis.py
@@ -73,13 +73,12 @@ def get_unique_directives(root_config: RootNginxConfig) -> List[str]:
     Find all unique directives in the given root config
     """
     unique_directives: Set[str] = set()
-    for file_config in root_config.config:
-        for line_config in file_config.parsed:
-            directives = get_unique_directives_in_line(line_config)
-            logger.debug(
-                f"Found directives on line {line_config.line} in file {file_config.file}: {directives}"
-            )
-            unique_directives = unique_directives.union(directives)
+    for line_config in root_config.lines:
+        directives = get_unique_directives_in_line(line_config)
+        logger.debug(
+            f"Found directives on line {line_config.line} in file {line_config.file}: {directives}"
+        )
+        unique_directives = unique_directives.union(directives)
     return list(unique_directives)
 
 
@@ -168,7 +167,7 @@ def filter_config(
 
 
 def get_directive_matches(
-    lines: List[NginxLineConfig], directives: List[str]
+    lines: Iterator[NginxLineConfig], directives: List[str]
 ) -> List[NginxLineConfig]:
     """
     Find all lines that match one of the given directives

--- a/nginx_analysis/analysis.py
+++ b/nginx_analysis/analysis.py
@@ -160,8 +160,10 @@ def filter_config(
     """
     matching_lines = []
     for line in lines:
-        child_matches, _ = find_matches_in_children(line, filters)
-        matching_lines.extend(child_matches)
+        child_matches, matched_filters = find_matches_in_children(line, filters)
+        if len(matched_filters) == len(filters):
+            logger.debug(f"Matched all ({len(matched_filters)}) filters: {line}")
+            matching_lines.extend(child_matches)
 
     return filter_unique(matching_lines)
 

--- a/nginx_analysis/dataclasses.py
+++ b/nginx_analysis/dataclasses.py
@@ -149,6 +149,14 @@ class RootNginxConfig(BaseModel):
     config: List[NginxFileConfig]
 
     @property
+    def root_file(self) -> Path:
+        return self.config[0].file
+
+    @property
+    def root_dir(self) -> Path:
+        return self.root_file.absolute().parent
+
+    @property
     def lines(self) -> Generator[NginxLineConfig, None, None]:
         # After parsing, the root config contains a list of files
         # with lines that are linked to each other. We loop over

--- a/tests/integration/test_directive.py
+++ b/tests/integration/test_directive.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from nginx_analysis.analysis import filter_config
 from nginx_analysis.dataclasses import DirectiveFilter, NginxLineConfig
 from tests.testcase import TestCase
@@ -9,10 +7,10 @@ class TestDirectiveIntegration(TestCase):
     maxDiff = None
 
     def test_one_user_is_parsed(self):
-        expected_line = NginxLineConfig(
-            line=1, file="/etc/nginx/nginx.conf", directive="user", args=["app"]
-        )
         root_config = self.get_example_root_conf()
+        expected_line = NginxLineConfig(
+            line=1, file=root_config.root_file, directive="user", args=["app"]
+        )
         user_filters = [DirectiveFilter(directive="user")]
         lines = filter_config(root_config.lines, user_filters)
         self.assertEqual(lines[0], expected_line)
@@ -24,13 +22,13 @@ class TestDirectiveIntegration(TestCase):
         expected_lines = [
             NginxLineConfig(
                 line=2,
-                file=Path("/etc/nginx/servers/example.com.conf"),
+                file=root_config.root_dir / "servers/example.com.conf",
                 directive="server_name",
                 args=["example.com", "www.example.com"],
             ),
             NginxLineConfig(
                 line=2,
-                file=Path("/etc/nginx/servers/testalex.hypernode.io.conf"),
+                file=root_config.root_dir / "servers/testalex.hypernode.io.conf",
                 directive="server_name",
                 args=["testalex.hypernode.io"],
             ),
@@ -47,7 +45,7 @@ class TestDirectiveIntegration(TestCase):
         expected_lines = [
             NginxLineConfig(
                 line=2,
-                file=Path("/etc/nginx/servers/example.com.conf"),
+                file=root_config.root_dir / "servers/example.com.conf",
                 directive="server_name",
                 args=["example.com", "www.example.com"],
             ),

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -1,9 +1,14 @@
-from tempfile import NamedTemporaryFile
+import os
+from glob import glob
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import TestCase as BaseTestCase
 from unittest.mock import Mock, mock_open, patch
 
 from nginx_analysis.analysis import parse_config
 from nginx_analysis.dataclasses import RootNginxConfig
+
+PROJECT_DIR = Path(__file__).parent.parent
 
 
 class TestCase(BaseTestCase):
@@ -25,7 +30,28 @@ class TestCase(BaseTestCase):
         return self.set_up_patch("builtins.open", mock_open(read_data=read_value))
 
     def get_example_root_conf(self, file="/etc/nginx/nginx.conf") -> RootNginxConfig:
-        return parse_config(file)
+        # Copy the example config to a temporary directory so
+        # that we can rename /etc/nginx to the temporary directory
+        # in the Nginx config files
+        with TemporaryDirectory() as tmpdir:
+            # Copy all files in the example config to the temporary directory
+            for path in glob(f"{PROJECT_DIR}/example_nginx/**", recursive=True):
+                rel_path = path.split(f"{PROJECT_DIR}/example_nginx/")[1]
+                tempfile_path = f"{tmpdir}/{rel_path}"
+                if os.path.isdir(path):
+                    # Create the child tempdir
+                    os.makedirs(tempfile_path, exist_ok=True)
+                    continue
+
+                with open(path) as f:
+                    with open(tempfile_path, "w") as g:
+                        print(f"Copy {path} to {tempfile_path} from relpath {rel_path}")
+                        contents = f.read()
+                        contents = contents.replace("/etc/nginx", tmpdir)
+                        g.write(contents)
+
+            # Load the config from the tmpdir
+            return parse_config(f"{tmpdir}/nginx.conf")
 
     def load_nginx_config(self, config: str) -> RootNginxConfig:
         # Load config in a temporary file

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -45,7 +45,6 @@ class TestCase(BaseTestCase):
 
                 with open(path) as f:
                     with open(tempfile_path, "w") as g:
-                        print(f"Copy {path} to {tempfile_path} from relpath {rel_path}")
                         contents = f.read()
                         contents = contents.replace("/etc/nginx", tmpdir)
                         g.write(contents)

--- a/tests/unit/analysis/test_find_matches_in_children.py
+++ b/tests/unit/analysis/test_find_matches_in_children.py
@@ -1,0 +1,89 @@
+from nginx_analysis.analysis import find_matches_in_children
+from nginx_analysis.dataclasses import DirectiveFilter, NginxLineConfig
+from tests.testcase import TestCase
+
+
+class TestFindMatchesInChildren(TestCase):
+    def test_return_empty_list_if_no_children_and_no_match(self):
+        line = NginxLineConfig(
+            directive="return",
+            args=["404"],
+            line=1,
+        )
+        dfilter = DirectiveFilter(directive="location", value="/")
+        self.assertEqual(find_matches_in_children(line, filters=[dfilter]), ([], []))
+        self.assertEqual(find_matches_in_children(line, filters=[dfilter]), ([], []))
+
+    def test_return_empty_list_if_args_dont_match(self):
+        line = NginxLineConfig(
+            directive="return",
+            args=["404"],
+            line=1,
+        )
+        dfilter = DirectiveFilter(directive="return", value="123")
+        self.assertEqual(find_matches_in_children(line, filters=[dfilter]), ([], []))
+        self.assertEqual(find_matches_in_children(line, filters=[dfilter]), ([], []))
+
+    def test_return_line_if_direct_match(self):
+        line = NginxLineConfig(
+            directive="return",
+            args=["404"],
+            line=1,
+        )
+        dfilter = DirectiveFilter(directive="return", value="404")
+        self.assertEqual(
+            find_matches_in_children(line, filters=[dfilter]), ([line], [dfilter])
+        )
+
+    def test_return_line_if_direct_match_for_one_filter(self):
+        line = NginxLineConfig(
+            directive="return",
+            args=["404"],
+            line=1,
+        )
+        dfilter1 = DirectiveFilter(directive="return", value="404")
+        dfilter2 = DirectiveFilter(directive="return", value="405")
+        self.assertEqual(
+            find_matches_in_children(line, filters=[dfilter1, dfilter2]),
+            ([line], [dfilter1]),
+        )
+
+    def test_return_parent_and_children_if_match_child(self):
+        parent = NginxLineConfig(
+            directive="location",
+            args=["/"],
+            line=1,
+        )
+        line = NginxLineConfig(
+            directive="return",
+            args=["404"],
+            line=1,
+        )
+        line.parent = parent
+        parent.children.append(line)
+
+        dfilter = DirectiveFilter(directive="return", value="404")
+        self.assertEqual(
+            find_matches_in_children(parent, filters=[dfilter]),
+            ([parent, line], [dfilter]),
+        )
+
+    def test_return_parent_and_children_if_match_parent(self):
+        parent = NginxLineConfig(
+            directive="location",
+            args=["/"],
+            line=1,
+        )
+        line = NginxLineConfig(
+            directive="return",
+            args=["404"],
+            line=1,
+        )
+        line.parent = parent
+        parent.children.append(line)
+
+        dfilter = DirectiveFilter(directive="location", value="/")
+        self.assertEqual(
+            find_matches_in_children(parent, filters=[dfilter]),
+            ([parent, line], [dfilter]),
+        )

--- a/tests/unit/analysis/test_get_unique_directives.py
+++ b/tests/unit/analysis/test_get_unique_directives.py
@@ -1,0 +1,45 @@
+from nginx_analysis.analysis import get_unique_directives
+from tests.testcase import TestCase
+
+
+class TestGetUniqueDirectives(TestCase):
+    maxDiff = None
+
+    def test_get_unique_directives(self):
+        root_config = self.get_example_root_conf()
+        self.assertListEqual(
+            sorted(get_unique_directives(root_config)),
+            [
+                "default_type",
+                "events",
+                "gzip",
+                "gzip_disable",
+                "gzip_min_length",
+                "gzip_proxied",
+                "gzip_types",
+                "http",
+                "include",
+                "index",
+                "keepalive_timeout",
+                "limit_conn_status",
+                "limit_req_log_level",
+                "limit_req_status",
+                "listen",
+                "location",
+                "map_hash_bucket_size",
+                "pid",
+                "proxy_pass",
+                "return",
+                "sendfile",
+                "server",
+                "server_name",
+                "server_names_hash_bucket_size",
+                "server_tokens",
+                "tcp_nodelay",
+                "tcp_nopush",
+                "types_hash_max_size",
+                "user",
+                "worker_connections",
+                "worker_processes",
+            ],
+        )

--- a/tests/unit/analysis/test_parse_config.py
+++ b/tests/unit/analysis/test_parse_config.py
@@ -1,0 +1,54 @@
+from nginx_analysis.analysis import get_directive_matches
+from tests.testcase import TestCase
+
+
+class TestParseConfig(TestCase):
+    def test_parent_is_set_on_include_block(self):
+        root_config = self.get_example_root_conf()
+        include_lines = get_directive_matches(root_config.lines, ["include"])
+        self.assertGreater(len(include_lines), 0)
+        for include_line in include_lines:
+            self.assertEqual(include_line.directive, "include")
+            self.assertGreater(len(include_line.children), 0)
+            for child in include_line.children:
+                self.assertEqual(child.parent, include_line)
+
+    def test_http_has_no_parent(self):
+        root_config = self.get_example_root_conf()
+        http_lines = get_directive_matches(root_config.lines, ["http"])
+        self.assertEqual(len(http_lines), 1)
+        self.assertIsNone(http_lines[0].parent)
+
+    def test_include_parent_is_http(self):
+        root_config = self.get_example_root_conf()
+        include_lines = get_directive_matches(root_config.lines, ["include"])
+        self.assertGreater(len(include_lines), 0)
+        for include_line in include_lines:
+            self.assertEqual(include_line.parent.directive, "http")
+
+    def test_include_has_no_block(self):
+        root_config = self.get_example_root_conf()
+        include_lines = get_directive_matches(root_config.lines, ["include"])
+        self.assertGreater(len(include_lines), 0)
+        for include_line in include_lines:
+            self.assertIsNone(include_line.block)
+
+    def test_http_has_block(self):
+        root_config = self.get_example_root_conf()
+        http_lines = get_directive_matches(root_config.lines, ["http"])
+        self.assertEqual(len(http_lines), 1)
+        self.assertIsNotNone(http_lines[0].block)
+
+    def test_server_has_block(self):
+        root_config = self.get_example_root_conf()
+        server_lines = get_directive_matches(root_config.lines, ["server"])
+        self.assertGreater(len(server_lines), 0)
+        for server_line in server_lines:
+            self.assertIsNotNone(server_line.block)
+
+    def test_location_has_block(self):
+        root_config = self.get_example_root_conf()
+        location_lines = get_directive_matches(root_config.lines, ["location"])
+        self.assertGreater(len(location_lines), 0)
+        for location_line in location_lines:
+            self.assertIsNotNone(location_line.block)

--- a/tests/unit/dataclasses/test_root_nginx_config.py
+++ b/tests/unit/dataclasses/test_root_nginx_config.py
@@ -1,0 +1,14 @@
+from tests.testcase import TestCase
+
+
+class TestRootNginxConfig(TestCase):
+    def test_root_config_contains_all_included_files(self):
+        root_config = self.get_example_root_conf()
+        self.assertEqual(
+            [c.file for c in root_config.config],
+            [
+                root_config.root_dir / "nginx.conf",
+                root_config.root_dir / "servers/example.com.conf",
+                root_config.root_dir / "servers/testalex.hypernode.io.conf",
+            ],
+        )


### PR DESCRIPTION
Simplified the example configs a bit so that it's easier to test. Less garbage means cleaner overview.