### PR TITLE
Optimize speed of filtering unique lines

### DIFF
--- a/nginx_analysis/dataclasses.py
+++ b/nginx_analysis/dataclasses.py
@@ -18,11 +18,7 @@ def filter_unique(line_configs: List["NginxLineConfig"]) -> List["NginxLineConfi
     """
     Filter out lines that are already covered by a parent.
     """
-    filtered_lines = []
-    for line_config in line_configs:
-        if not line_config in filtered_lines:
-            filtered_lines.append(line_config)
-    return filtered_lines
+    return list(set(line_configs))
 
 
 def get_children_recursive(line_config: "NginxLineConfig") -> List["NginxLineConfig"]:


### PR DESCRIPTION
Before:
```
         604331906 function calls (603658051 primitive calls) in 115.921 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
118730082   36.229    0.000   97.200    0.000 dataclasses.py:98(__eq__)
118730082   32.958    0.000   52.859    0.000 dataclasses.py:10(compare_objects)
237717531   19.893    0.000   19.893    0.000 {built-in method builtins.getattr}
        1   12.585   12.585  109.784  109.784 dataclasses.py:17(filter_unique)
118766577    8.116    0.000    8.116    0.000 {built-in method builtins.isinstance}
345466/75694    0.909    0.000    4.433    0.000 analysis.py:110(get_matching_lines_in_children)
```

After:
```
         11052807 function calls (10378952 primitive calls) in 6.210 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
345466/75694    0.895    0.000    4.334    0.000 analysis.py:110(get_matching_lines_in_children)
   422831    0.646    0.000    2.195    0.000 _datetime.py:81(aware_now)
   422831    0.471    0.000    0.471    0.000 {built-in method now}
   422831    0.447    0.000    0.447    0.000 {method 'replace' of 'datetime.datetime' objects}
   422830    0.423    0.000    2.936    0.000 _logger.py:1841(_log)
   422831    0.322    0.000    0.322    0.000 {method 'timestamp' of 'datetime.datetime' objects}
   422831    0.309    0.000    0.309    0.000 {built-in method time.localtime}
   476578    0.258    0.000    0.322    0.000 dataclasses.py:110(__repr__)
        1    0.211    0.211    0.933    0.933 analysis.py:74(get_unique_directives)
   422829    0.198    0.000    2.884    0.000 _logger.py:1965(debug)
```